### PR TITLE
Structured JSON logging with cross-server request IDs (#51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,27 @@ Clients may send `Content-Digest` or `Repr-Digest` with a SHA-256 value (`sha-25
 - **`/health` response renamed `available` to `quota-available-bytes`** (RFC 4331 alignment) and added a `quota-used-bytes` field. Clients reading the old `available` key will break and must switch to `quota-available-bytes`. This applies to the object server's `/health` body and to each per-server entry under `servers` in the locator's `/health` body.
 - **`GET /`** now returns `403` on both the object server and the locator (previously `404`, as no route existed). Bucket enumeration is intentionally not offered.
 
+## Logging
+
+The object server, locator, and `async_replicate` CLI emit one JSON object per line on stderr. Verbosity is set by the `LOG_LEVEL` environment variable (default `INFO`):
+
+```
+LOG_LEVEL=INFO fastapi run simpler_objects/object_server.py | jq .
+```
+
+Example PUT through the cluster (one client request → one locator log line → one object-server log line):
+
+```json
+{"ts":"2026-05-22T18:04:11Z","level":"INFO","logger":"simpler_objects.locator_api","msg":"locator.put.select","request_id":"6d49ca3e...","bucket":"mybucket","key":"hello","server":"http://127.0.0.1:39172/","content_length":17,"weight":395178651648}
+{"ts":"2026-05-22T18:04:11Z","level":"INFO","logger":"simpler_objects.object_server","msg":"object.put","request_id":"6d49ca3e...","bucket":"mybucket","key":"hello","size":17,"sha256_hex":"dfc8ae33..."}
+```
+
+The shared `request_id` lets you correlate locator + object-server log lines for the same request. The locator generates one per inbound request (or honours an inbound `X-Request-Id` header) and propagates it on every outbound call to an object server. The bundled `simpler_objects.client` library generates its own ID and sends it on the wire so a client-driven upload's locator log line and the object-server log line share an ID.
+
+Third-party HTTP clients that follow the locator's `307` without forwarding `X-Request-Id` will produce two unrelated IDs (one for the locator request, a fresh one for the object-server request). Set the header yourself if cross-hop tracing matters.
+
+For production `fastapi run` / `uvicorn` deployments where uvicorn's default text config would otherwise be reloaded, write the dict returned by `simpler_objects.logging_config.configure()` to a JSON file and pass it via `uvicorn --log-config path.json`.
+
 ## CORS
 
 CORS headers are not configured by default. Web browsers making cross-origin requests will be blocked. To enable browser access from a different origin, add FastAPI's `CORSMiddleware` or place the service behind a reverse proxy that adds the appropriate `Access-Control-Allow-*` headers. Note that `Repr-Digest` is a non-standard response header and would need to be explicitly listed in `Access-Control-Expose-Headers` for JavaScript clients to read it.

--- a/simpler_objects/async_replicate.py
+++ b/simpler_objects/async_replicate.py
@@ -1,11 +1,16 @@
 """Basic simple bucket async replication"""
 
 import argparse
-import warnings
+import logging
 import random
 import sys
 import httpx
 from simpler_objects.common import filter_write_candidates
+from simpler_objects.logging_config import configure
+
+# Explicit name (rather than __name__) so the logger label stays stable when
+# the module is run as __main__ via `python -m simpler_objects.async_replicate`.
+logger = logging.getLogger("simpler_objects.async_replicate")
 
 TIMEOUT=2048
 
@@ -84,7 +89,10 @@ def auto_replica(locator, bucket, replicas):
     error = False
     for name, obj in contents['objects'].items():
         if obj['error'] or not obj['checksum']:
-            warnings.warn(f'Object {name} has an issue.')
+            logger.warning("replicate.skip", extra={
+                "bucket": bucket, "key": name,
+                "reason": "listing_error" if obj['error'] else "missing_checksum",
+            })
             error = True
             continue
         desired = replicas - len(obj['locations'])
@@ -92,17 +100,31 @@ def auto_replica(locator, bucket, replicas):
             continue
         spaces = find_space(locator, bucket, obj['size'], obj['locations'], desired)
         if not spaces:
-            warnings.warn(f'No space to replicate object {name}')
+            logger.warning("replicate.no_space", extra={
+                "bucket": bucket, "key": name,
+                "current_locations": obj['locations'],
+                "desired_extra": desired,
+            })
             error = True
             continue
         if len(spaces) < desired:
-            warnings.warn('Not enough spaces but will still do some...')
+            logger.warning("replicate.partial", extra={
+                "bucket": bucket, "key": name,
+                "got": len(spaces), "wanted": desired,
+            })
             error = True
         for run in spaces:
             src = random.choice(obj['locations']) + bucket + '/' + name
             dst = run +  bucket + '/' + name
-            print(f"{src} => {dst}")
-            assert replicate_object(src, dst) == obj['size']
+            logger.info("replicate.copy", extra={
+                "bucket": bucket, "key": name, "src": src, "dst": dst,
+            })
+            copied = replicate_object(src, dst)
+            assert copied == obj['size']
+            logger.info("replicate.copy.done", extra={
+                "bucket": bucket, "key": name, "src": src, "dst": dst,
+                "size": copied,
+            })
     return not error
 
 
@@ -115,6 +137,7 @@ def cli():
     parser.add_argument("bucket")
     parser.add_argument("replicas", type=int)
     args = parser.parse_args()
+    configure()
     #replicate_bucket(args.source, args.dest)
     sys.exit(int(not auto_replica(args.locator, args.bucket, args.replicas)))
 

--- a/simpler_objects/client.py
+++ b/simpler_objects/client.py
@@ -11,13 +11,19 @@ import base64
 import datetime
 import hashlib
 import io
+import logging
 import mimetypes
 import pathlib
+import uuid
 
 import pycurl
 
 BLOCK_SIZE = 16 * 1024 * 1024  # 16 MiB streaming chunk
 _DOWNLOAD_BUFFER = 256 * 1024  # libcurl receive buffer size for downloads
+
+# Library logger — silent unless the embedding application configures handlers.
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 
 class ClientError(Exception):
@@ -107,6 +113,11 @@ def simple_upload(filename, url, file_mime=None, checksum_val=None) -> bytes:
     if checksum_val is None:
         checksum_val = file_checksum(path)
 
+    request_id = uuid.uuid4().hex
+    logger.debug("client.upload.start", extra={
+        "url": url, "file_path": str(path), "file_size": size,
+        "sha256_hex": checksum_val.hex(), "client_request_id": request_id,
+    })
     response_headers: dict = {}
     curl = pycurl.Curl()
     curl.setopt(pycurl.URL, url)
@@ -117,6 +128,7 @@ def simple_upload(filename, url, file_mime=None, checksum_val=None) -> bytes:
         'Expect: 100-continue',
         f'Content-Type: {file_mime}',
         f'Content-Digest: {encode_digest_header(checksum_val)}',
+        f'X-Request-Id: {request_id}',
     ])
     curl.setopt(pycurl.HEADERFUNCTION, _header_collector(response_headers))
     curl.setopt(pycurl.WRITEDATA, io.BytesIO())  # discard the empty 201 body
@@ -125,6 +137,8 @@ def simple_upload(filename, url, file_mime=None, checksum_val=None) -> bytes:
             curl.setopt(pycurl.READDATA, body)
             curl.perform()
         code = curl.getinfo(pycurl.RESPONSE_CODE)
+        redirects = curl.getinfo(pycurl.REDIRECT_COUNT)
+        total_time = curl.getinfo(pycurl.TOTAL_TIME)
     except pycurl.error as exc:
         raise ClientError(f"upload of {url} failed: {exc}") from exc
     finally:
@@ -134,7 +148,18 @@ def simple_upload(filename, url, file_mime=None, checksum_val=None) -> bytes:
         raise ClientError(f"upload of {url} failed: HTTP {code}", status=code)
     server_digest = parse_digest_header(response_headers.get('repr-digest'))
     if server_digest is not None and server_digest != checksum_val:
+        logger.warning("client.upload.digest_mismatch", extra={
+            "url": url, "client_request_id": request_id,
+            "expected_sha256_hex": checksum_val.hex(),
+            "server_sha256_hex": server_digest.hex(),
+        })
         raise ClientError(f"digest mismatch after upload of {url}")
+    logger.info("client.upload.done", extra={
+        "url": url, "file_size": size, "sha256_hex": checksum_val.hex(),
+        "status": code, "redirects": redirects,
+        "total_time_ms": round(total_time * 1000.0, 2),
+        "client_request_id": request_id,
+    })
     return checksum_val
 
 
@@ -147,13 +172,20 @@ def simple_download(url, filename):
     Returns ``(digest, mime, sugg_fname, mtime)``.
     """
     path = pathlib.Path(filename)
+    request_id = uuid.uuid4().hex
+    logger.debug("client.download.start", extra={
+        "url": url, "file_path": str(path), "client_request_id": request_id,
+    })
     response_headers: dict = {}
     digest = hashlib.sha256()
     curl = pycurl.Curl()
     curl.setopt(pycurl.URL, url)
     curl.setopt(pycurl.FOLLOWLOCATION, 1)
     curl.setopt(pycurl.BUFFERSIZE, _DOWNLOAD_BUFFER)
-    curl.setopt(pycurl.HTTPHEADER, ['Want-Content-Digest: sha-256=9'])
+    curl.setopt(pycurl.HTTPHEADER, [
+        'Want-Content-Digest: sha-256=9',
+        f'X-Request-Id: {request_id}',
+    ])
     curl.setopt(pycurl.HEADERFUNCTION, _header_collector(response_headers))
     try:
         with open(path, 'wb') as out:
@@ -163,6 +195,8 @@ def simple_download(url, filename):
             curl.setopt(pycurl.WRITEFUNCTION, _write)
             curl.perform()
         code = curl.getinfo(pycurl.RESPONSE_CODE)
+        redirects = curl.getinfo(pycurl.REDIRECT_COUNT)
+        total_time = curl.getinfo(pycurl.TOTAL_TIME)
     except pycurl.error as exc:
         path.unlink(missing_ok=True)
         raise ClientError(f"download of {url} failed: {exc}") from exc
@@ -177,8 +211,20 @@ def simple_download(url, filename):
     server_digest = parse_digest_header(response_headers.get('repr-digest'))
     if server_digest is not None and server_digest != file_digest:
         path.unlink(missing_ok=True)
+        logger.warning("client.download.digest_mismatch", extra={
+            "url": url, "client_request_id": request_id,
+            "computed_sha256_hex": file_digest.hex(),
+            "server_sha256_hex": server_digest.hex(),
+        })
         raise ClientError(f"digest mismatch after download of {url}")
 
+    logger.info("client.download.done", extra={
+        "url": url, "file_size": path.stat().st_size,
+        "sha256_hex": file_digest.hex(),
+        "status": code, "redirects": redirects,
+        "total_time_ms": round(total_time * 1000.0, 2),
+        "client_request_id": request_id,
+    })
     return (file_digest,
             response_headers.get('content-type'),
             read_content_disposition(response_headers.get('content-disposition')),

--- a/simpler_objects/locator_api.py
+++ b/simpler_objects/locator_api.py
@@ -1,6 +1,7 @@
 """Simpler Objects Locator API"""
 
 import asyncio
+import logging
 import os
 import random
 from contextlib import asynccontextmanager
@@ -9,11 +10,26 @@ import httpx
 from fastapi import FastAPI, HTTPException, Header
 from fastapi.responses import RedirectResponse, Response
 from simpler_objects.common import filter_write_candidates
+from simpler_objects.logging_config import (
+    configure,
+    install_request_id_middleware,
+    request_id_var,
+)
+
+configure()
+logger = logging.getLogger(__name__)
 
 OBJECT_SERVERS = os.environ.get('OBJECT_SERVERS', 'http://localhost:46579/')
 
 # Fallback Retry-After on a busy 503; matches the object server's own constant.
 RETRY_AFTER = "64"
+
+
+def _outbound_headers() -> dict:
+    """Headers to forward on outbound httpx calls; propagates the request ID."""
+    rid = request_id_var.get()
+    return {"X-Request-Id": rid} if rid else {}
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -24,6 +40,7 @@ async def lifespan(app: FastAPI):
     await app.state.client.aclose()
 
 app = FastAPI(lifespan=lifespan)
+install_request_id_middleware(app)
 
 def object_servers(randomized=False):
     """Return a randomized list of object server URLs"""
@@ -36,9 +53,11 @@ async def get_object_server_health(url: str):
     """Get the health of an object server"""
     client = app.state.client
     try:
-        result = await client.get(url + 'health', timeout=1)
+        result = await client.get(url + 'health', timeout=1, headers=_outbound_headers())
         result.raise_for_status()
-    except httpx.HTTPError:
+    except httpx.HTTPError as exc:
+        logger.debug("locator.health.unreachable",
+                     extra={"server": url, "error": str(exc)})
         return {'write': False, 'read': False, 'quota-available-bytes': 0, 'quota-used-bytes': 0, 'percent': 0}
     return result.json()
 
@@ -61,27 +80,48 @@ async def find_object(bucket: str, key: str):
     # "retry forever" whenever any node in the fleet is flaky.
     busy = False
     retry_after = None
+    busy_servers: list[str] = []
+    probed: dict[str, int | None] = {}
     client = app.state.client
     # Sequential by design: randomised order spreads load; first healthy server wins.
     for server in object_servers(randomized=True):
         try:
-            result = await client.head(server + object_path, timeout=1)
-        except httpx.HTTPError:
+            result = await client.head(server + object_path, timeout=1,
+                                       headers=_outbound_headers())
+        except httpx.HTTPError as exc:
+            probed[server] = None
+            logger.debug("locator.find.probe.error",
+                         extra={"server": server, "key": object_path,
+                                "error": str(exc)})
             continue
+        probed[server] = result.status_code
+        logger.debug("locator.find.probe",
+                     extra={"server": server, "key": object_path,
+                            "status": result.status_code})
         if result.status_code == 200:
+            logger.info("locator.find.redirect",
+                        extra={"bucket": bucket, "key": key, "server": server})
             return RedirectResponse(url=server + object_path)
         if result.status_code == 503:
             busy = True
+            busy_servers.append(server)
             retry_after = result.headers.get("Retry-After", retry_after)
     if busy:
+        logger.warning("locator.find.busy",
+                       extra={"bucket": bucket, "key": key,
+                              "busy_servers": busy_servers, "probed": probed})
         raise HTTPException(status_code=503,
                             headers={"Retry-After": retry_after or RETRY_AFTER})
+    logger.info("locator.find.missing",
+                extra={"bucket": bucket, "key": key, "probed": probed})
     raise HTTPException(status_code=404)
 
 @app.put("/{bucket}/{key}")
 async def add_object(bucket: str, key: str, content_length: Annotated[int | None, Header()] = None):
     """Return a redirect to a server that can handle an object request"""
     if content_length is None:
+        logger.warning("locator.put.no_content_length",
+                       extra={"bucket": bucket, "key": key})
         raise HTTPException(status_code=411)
     object_path = f"{bucket}/{key}"
     # TODO use caches of objects and servers but then double check vs checking everybody
@@ -90,7 +130,8 @@ async def add_object(bucket: str, key: str, content_length: Annotated[int | None
 
     async def check_exists(server):
         try:
-            result = await client.head(server + object_path, timeout=1)
+            result = await client.head(server + object_path, timeout=1,
+                                       headers=_outbound_headers())
             return server, result.status_code
         except httpx.HTTPError:
             return server, None
@@ -105,15 +146,24 @@ async def add_object(bucket: str, key: str, content_length: Annotated[int | None
 
     health = dict(zip(all_obj_servers, healths))
     candidates = filter_write_candidates(health, content_length)
+    logger.debug("locator.put.candidates",
+                 extra={"bucket": bucket, "key": key,
+                        "content_length": content_length,
+                        "writable": list(candidates.keys()),
+                        "exist_results": dict(exist_results)})
     for server, status in exist_results:
         if status is None:
             candidates.pop(server, None)
         elif status != 404:
+            logger.warning("locator.put.conflict",
+                           extra={"bucket": bucket, "key": key,
+                                  "existing_server": server, "status": status})
             raise HTTPException(status_code=409)
 
     async def check_bucket(server):
         try:
-            result = await client.head(server + bucket + "/", timeout=1)
+            result = await client.head(server + bucket + "/", timeout=1,
+                                       headers=_outbound_headers())
             result.raise_for_status()
             return server, True
         except httpx.HTTPError:
@@ -127,8 +177,20 @@ async def add_object(bucket: str, key: str, content_length: Annotated[int | None
             candidates.pop(server, None)
 
     if not candidates:
+        logger.error("locator.put.no_space",
+                     extra={"bucket": bucket, "key": key,
+                            "content_length": content_length,
+                            "bucket_results": dict(bucket_results)})
         raise HTTPException(507)
-    server_to_upload = random.choices(list(candidates.keys()), list(candidates.values()))[0]
+    chosen = list(candidates.keys())
+    weights = list(candidates.values())
+    server_to_upload = random.choices(chosen, weights)[0]
+    logger.info("locator.put.select",
+                extra={"bucket": bucket, "key": key,
+                       "server": server_to_upload,
+                       "content_length": content_length,
+                       "candidates": chosen,
+                       "weight": candidates[server_to_upload]})
     return RedirectResponse(url=server_to_upload+object_path)
 
 @app.get("/")
@@ -143,19 +205,25 @@ async def head_bucket(bucket: str):
 
     async def check_server(server):
         try:
-            result = await client.head(server + bucket + "/", timeout=2)
+            result = await client.head(server + bucket + "/", timeout=2,
+                                       headers=_outbound_headers())
             return result.status_code
         except httpx.HTTPError:
             return None
 
     # All servers queried in parallel; any 200 means the bucket exists.
-    statuses = await asyncio.gather(*[check_server(s) for s in object_servers()])
+    servers = object_servers()
+    statuses = await asyncio.gather(*[check_server(s) for s in servers])
+    by_server = dict(zip(servers, statuses))
 
     if 200 in statuses:
         return Response(status_code=200)
     if any(s != 404 for s in statuses):
         # 503, not 502/504: the locator coordinates object servers but is not
         # itself a gateway/proxy, so gateway-specific codes don't apply.
+        logger.warning("locator.bucket.upstream_error",
+                       extra={"bucket": bucket, "op": "head",
+                              "statuses": by_server})
         raise HTTPException(status_code=503)
     raise HTTPException(status_code=404)
 
@@ -166,7 +234,8 @@ async def list_bucket(bucket: str):
 
     async def fetch_server(server):
         try:
-            result = await client.get(server + bucket + '/', timeout=2)
+            result = await client.get(server + bucket + '/', timeout=2,
+                                      headers=_outbound_headers())
         except httpx.HTTPError:
             return server, None
         return server, result
@@ -180,6 +249,10 @@ async def list_bucket(bucket: str):
         if result is None or result.status_code not in (200, 404):
             # 503, not 502/504: the locator coordinates object servers but is
             # not itself a gateway/proxy, so gateway-specific codes don't apply.
+            logger.warning("locator.bucket.upstream_error",
+                           extra={"bucket": bucket, "op": "list",
+                                  "server": server,
+                                  "status": result.status_code if result else None})
             raise HTTPException(503)
         if result.status_code == 404:
             continue

--- a/simpler_objects/logging_config.py
+++ b/simpler_objects/logging_config.py
@@ -1,0 +1,151 @@
+"""Structured logging for Simpler Objects.
+
+Single owner of the JSON-lines log format and the per-request ``X-Request-Id``
+contextvar that lets a locator log line be tied to the object-server log line
+it triggered.
+
+Server entry points (``object_server.py``, ``locator_api.py``) and the CLI
+(``async_replicate.py``) call :func:`configure`. The client library
+(``client.py``) attaches a :class:`NullHandler` and lets its embedder decide.
+"""
+
+import contextvars
+import datetime
+import json
+import logging
+import logging.config
+import os
+import sys
+import time
+import uuid
+
+# Set by the FastAPI middleware (see install_request_id_middleware); read by
+# JsonFormatter so every record inside a request inherits the same ID.
+request_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "request_id", default=None
+)
+
+# LogRecord fields populated by the logging machinery itself. Anything else on
+# the record came from logger.<level>(..., extra={...}) and should land in the
+# JSON output as a structured field.
+_STD_ATTRS = frozenset({
+    "args", "asctime", "created", "exc_info", "exc_text", "filename",
+    "funcName", "levelname", "levelno", "lineno", "message", "module",
+    "msecs", "msg", "name", "pathname", "process", "processName",
+    "relativeCreated", "stack_info", "thread", "threadName", "taskName",
+})
+
+
+class JsonFormatter(logging.Formatter):
+    """Render a LogRecord as a single-line JSON object."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict = {
+            "ts": datetime.datetime.fromtimestamp(
+                record.created, tz=datetime.timezone.utc
+            ).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "msg": record.getMessage(),
+        }
+        # An explicit attribute on the record (set by a filter) wins over the
+        # contextvar so callers can override per-record if they need to.
+        rid = getattr(record, "request_id", None) or request_id_var.get()
+        if rid is not None:
+            payload["request_id"] = rid
+        for key, value in record.__dict__.items():
+            if key in _STD_ATTRS or key.startswith("_") or key == "request_id":
+                continue
+            payload[key] = value
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(payload, default=str)
+
+
+def configure(level: str | None = None) -> dict:
+    """Install the JSON formatter on stderr. Safe to call multiple times.
+
+    Precedence: explicit ``level`` arg, then ``LOG_LEVEL`` env var, then INFO.
+    Returns the dictConfig so it can be persisted to a JSON file and passed to
+    uvicorn via ``--log-config`` for production deployments where ``fastapi
+    run`` would otherwise reset the config to its text default.
+    """
+    resolved = (level or os.environ.get("LOG_LEVEL") or "INFO").upper()
+    config = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "json": {"()": "simpler_objects.logging_config.JsonFormatter"},
+        },
+        "handlers": {
+            "stderr": {
+                "class": "logging.StreamHandler",
+                "stream": sys.stderr,
+                "formatter": "json",
+            },
+        },
+        # Empty handler lists + propagate=True replace uvicorn's own text
+        # handlers and route every record through the single root stderr/JSON
+        # handler. caplog (which hooks at root) sees our records too.
+        "loggers": {
+            "simpler_objects": {"level": resolved, "handlers": [], "propagate": True},
+            "uvicorn": {"level": resolved, "handlers": [], "propagate": True},
+            "uvicorn.error": {"level": resolved, "handlers": [], "propagate": True},
+            "uvicorn.access": {"level": resolved, "handlers": [], "propagate": True},
+        },
+        "root": {"level": resolved, "handlers": ["stderr"]},
+    }
+    logging.config.dictConfig(config)
+    return config
+
+
+def install_request_id_middleware(app) -> None:
+    """Attach a FastAPI middleware that owns the per-request X-Request-Id.
+
+    Honours an inbound ``X-Request-Id`` header (so the locator can pass its ID
+    through to the object server) and generates a uuid4 hex string otherwise.
+    Echoes the ID back on the response so callers can correlate.
+
+    ``/health`` is demoted to DEBUG to avoid swamping logs with health-check
+    chatter; everything else logs request.start + request.end at INFO.
+    """
+    from starlette.requests import Request
+
+    logger = logging.getLogger("simpler_objects.request")
+
+    @app.middleware("http")
+    async def _request_id_middleware(request: Request, call_next):
+        rid = request.headers.get("X-Request-Id") or uuid.uuid4().hex
+        token = request_id_var.set(rid)
+        start = time.monotonic()
+        is_health = request.url.path == "/health"
+        level = logging.DEBUG if is_health else logging.INFO
+        client_ip = request.client.host if request.client else None
+        try:
+            logger.log(level, "request.start", extra={
+                "method": request.method,
+                "path": request.url.path,
+                "client_ip": client_ip,
+                "content_length": request.headers.get("content-length"),
+            })
+            try:
+                response = await call_next(request)
+            except Exception:
+                latency_ms = round((time.monotonic() - start) * 1000.0, 2)
+                logger.error("request.crash", exc_info=True, extra={
+                    "method": request.method,
+                    "path": request.url.path,
+                    "latency_ms": latency_ms,
+                })
+                raise
+            latency_ms = round((time.monotonic() - start) * 1000.0, 2)
+            logger.log(level, "request.end", extra={
+                "method": request.method,
+                "path": request.url.path,
+                "status": response.status_code,
+                "latency_ms": latency_ms,
+            })
+            response.headers["X-Request-Id"] = rid
+            return response
+        finally:
+            request_id_var.reset(token)

--- a/simpler_objects/object_server.py
+++ b/simpler_objects/object_server.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import errno
+import logging
 import pathlib
 import shutil
 import base64
@@ -12,7 +13,13 @@ from typing import Annotated
 from fastapi import FastAPI, HTTPException, Header, Request
 from fastapi.responses import FileResponse, Response
 
+from simpler_objects.logging_config import configure, install_request_id_middleware
+
+configure()
+logger = logging.getLogger(__name__)
+
 app = FastAPI()
+install_request_id_middleware(app)
 
 OBJECT_DIRECTORY = os.environ.get('OBJECT_DIRECTORY', '.')
 READ_ONLY = bool(os.environ.get('READ_ONLY', ''))
@@ -28,6 +35,11 @@ def safe_path(base: pathlib.Path, *parts) -> pathlib.Path:
     resolved_base = base.resolve()
     candidate = base.joinpath(*parts).resolve()
     if not candidate.is_relative_to(resolved_base):
+        logger.warning("path.traversal", extra={
+            "base": str(resolved_base),
+            "attempted": str(candidate),
+            "parts": [str(p) for p in parts],
+        })
         raise HTTPException(status_code=404)
     return candidate
 
@@ -82,6 +94,11 @@ def append_checksum(path: pathlib.Path, file_digest: bytes):
         os.fsync(fd)
     finally:
         os.close(fd)
+    logger.debug("checksum.append", extra={
+        "bucket": path.parent.name,
+        "key": path.name,
+        "sha256_hex": file_digest.hex(),
+    })
 
 def read_checksum(bucket_dir: pathlib.Path, key: str):
     """Return the recorded SHA-256 digest for a key, or None.
@@ -91,12 +108,18 @@ def read_checksum(bucket_dir: pathlib.Path, key: str):
     """
     try:
         with open(checksum_filename(bucket_dir), encoding='utf-8') as fp:
-            for line in fp:
+            for line_no, line in enumerate(fp, start=1):
                 parts = line.strip().split()
                 # A valid sha256sum line has exactly two fields and a 64-char hex digest.
                 # Fewer/more fields catches truly torn lines; the length check catches a
                 # torn fragment that absorbed a later append (making one garbage field).
                 if len(parts) != 2 or len(parts[0]) != 64:
+                    logger.warning("checksum.torn", extra={
+                        "bucket": bucket_dir.name,
+                        "line_no": line_no,
+                        "field_count": len(parts),
+                        "digest_len": len(parts[0]) if parts else 0,
+                    })
                     continue
                 checksum, file_name = parts
                 if file_name == key:
@@ -128,6 +151,9 @@ def get_object(bucket: str, key: str):
     try:
         fd = os.open(path, os.O_RDONLY)
     except FileNotFoundError:
+        logger.info("object.get.missing", extra={
+            "bucket": bucket, "key": key, "phase": "open",
+        })
         raise HTTPException(status_code=404) from None
     try:
         # A shared lock, tested non-blocking: if a PUT holds the exclusive
@@ -135,11 +161,17 @@ def get_object(bucket: str, key: str):
         try:
             fcntl.flock(fd, fcntl.LOCK_SH | fcntl.LOCK_NB)
         except BlockingIOError:
+            logger.warning("object.get.busy", extra={
+                "bucket": bucket, "key": key,
+            })
             raise HTTPException(status_code=503,
                                 headers={"Retry-After": RETRY_AFTER}) from None
         # Re-check: a PUT that failed may have unlinked the file between the
         # open above and acquiring the lock.
         if not path.is_file():
+            logger.info("object.get.missing", extra={
+                "bucket": bucket, "key": key, "phase": "post-lock",
+            })
             raise HTTPException(status_code=404)
         my_cksum = read_checksum(path.parent, key)
     finally:
@@ -147,6 +179,12 @@ def get_object(bucket: str, key: str):
     headers = None
     if my_cksum:
         headers = {"Repr-Digest": http_digest_head(my_cksum)}
+    logger.info("object.get", extra={
+        "bucket": bucket,
+        "key": key,
+        "size": path.stat().st_size,
+        "sha256_hex": my_cksum.hex() if my_cksum else None,
+    })
     return FileResponse(path, headers=headers)
 
 @app.put("/{bucket}/{key}")
@@ -162,8 +200,10 @@ async def put_object(bucket: str, key: str, request: Request,
     try:
         fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
     except FileExistsError:
+        logger.info("object.put.conflict", extra={"bucket": bucket, "key": key})
         raise HTTPException(status_code=409) from None
     except (FileNotFoundError, NotADirectoryError):
+        logger.info("object.put.no_bucket", extra={"bucket": bucket, "key": key})
         raise HTTPException(status_code=404) from None
 
     try:
@@ -178,22 +218,51 @@ async def put_object(bucket: str, key: str, request: Request,
             # Offload the blocking commit steps (fsync, whole-file hash) so a
             # large upload does not stall the event loop for other requests.
             await asyncio.to_thread(os.fsync, fd)
-            if content_length is not None and os.fstat(fd).st_size != content_length:
+            actual_size = os.fstat(fd).st_size
+            if content_length is not None and actual_size != content_length:
+                logger.warning("object.put.mismatch", extra={
+                    "bucket": bucket, "key": key, "reason": "content_length",
+                    "expected_size": content_length, "actual_size": actual_size,
+                })
                 raise HTTPException(status_code=400)
             file_digest = await asyncio.to_thread(file_checksum, path)
             if request_digest and file_digest != request_digest:
+                logger.warning("object.put.mismatch", extra={
+                    "bucket": bucket, "key": key, "reason": "digest",
+                    "expected_sha256_hex": request_digest.hex(),
+                    "actual_sha256_hex": file_digest.hex(),
+                })
                 raise HTTPException(status_code=400)
             append_checksum(path, file_digest)
+            logger.info("object.put", extra={
+                "bucket": bucket,
+                "key": key,
+                "size": actual_size,
+                "sha256_hex": file_digest.hex(),
+            })
             return Response(status_code=201, content=None,
                             headers={"Repr-Digest": http_digest_head(file_digest)})
         except OSError as e:
             path.unlink(missing_ok=True)
             if e.errno == errno.ENOSPC:
+                logger.error("object.put.nospace", extra={
+                    "bucket": bucket, "key": key, "errno": e.errno,
+                })
                 raise HTTPException(status_code=507) from None
+            logger.error("object.put.crash", exc_info=True,
+                         extra={"bucket": bucket, "key": key})
+            raise
+        except HTTPException:
+            # Mismatch (400) already logged at WARNING above.
+            path.unlink(missing_ok=True)
+            raise
+        except Exception:
+            path.unlink(missing_ok=True)
+            logger.error("object.put.crash", exc_info=True,
+                         extra={"bucket": bucket, "key": key})
             raise
         except BaseException:
-            # Any non-crash failure (client disconnect, cancellation, bad
-            # length/digest) must leave no partial object behind.
+            # CancelledError / client disconnect: clean up quietly.
             path.unlink(missing_ok=True)
             raise
     finally:
@@ -223,9 +292,14 @@ def list_directory(bucket: str):
     hashes = {}
     try:
         with open(checksum_filename(dir_path), encoding='utf-8') as fp:
-            for line in fp:
+            for line_no, line in enumerate(fp, start=1):
                 parts = line.strip().split()
                 if len(parts) != 2:
+                    logger.warning("checksum.torn", extra={
+                        "bucket": bucket,
+                        "line_no": line_no,
+                        "field_count": len(parts),
+                    })
                     continue
                 checksum, file_name = parts
                 hashes[file_name] = checksum

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Test-suite logging defaults.
+
+The server modules call ``logging_config.configure()`` at import time with the
+INFO default, which spams stderr during pytest. This fixture rebinds the level
+to WARNING for every test (caplog can still raise it locally with
+``caplog.set_level(...)``).
+"""
+
+import pytest
+
+from simpler_objects.logging_config import configure
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _quiet_logging():
+    configure(level="WARNING")
+    yield

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -106,9 +106,10 @@ def servers(tmp_path_factory):
     obj_port, loc_port = _free_port(), _free_port()
 
     obj_proc = _spawn("object_server", obj_port,
-                      {"OBJECT_DIRECTORY": str(obj_dir)})
+                      {"OBJECT_DIRECTORY": str(obj_dir), "LOG_LEVEL": "WARNING"})
     loc_proc = _spawn("locator_api", loc_port,
-                      {"OBJECT_SERVERS": f"http://127.0.0.1:{obj_port}/"})
+                      {"OBJECT_SERVERS": f"http://127.0.0.1:{obj_port}/",
+                       "LOG_LEVEL": "WARNING"})
     try:
         if not (_wait_for(f"http://127.0.0.1:{obj_port}/health")
                 and _wait_for(f"http://127.0.0.1:{loc_port}/health")):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,128 @@
+"""Tests for the JSON formatter and request-id middleware."""
+
+import json
+import logging
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from simpler_objects.logging_config import (
+    JsonFormatter,
+    install_request_id_middleware,
+    request_id_var,
+)
+
+
+def _make_record(msg="hello", level=logging.INFO, extra=None, exc_info=None):
+    record = logging.LogRecord(
+        name="simpler_objects.test", level=level, pathname=__file__,
+        lineno=0, msg=msg, args=(), exc_info=exc_info,
+    )
+    if extra:
+        for k, v in extra.items():
+            setattr(record, k, v)
+    return record
+
+
+def test_json_formatter_basic_shape():
+    formatter = JsonFormatter()
+    record = _make_record("hi", extra={"bucket": "b", "key": "k", "size": 7})
+    payload = json.loads(formatter.format(record))
+    assert payload["msg"] == "hi"
+    assert payload["level"] == "INFO"
+    assert payload["logger"] == "simpler_objects.test"
+    assert payload["bucket"] == "b"
+    assert payload["key"] == "k"
+    assert payload["size"] == 7
+    assert "ts" in payload
+
+
+def test_json_formatter_request_id_from_contextvar():
+    formatter = JsonFormatter()
+    token = request_id_var.set("abc123")
+    try:
+        payload = json.loads(formatter.format(_make_record()))
+    finally:
+        request_id_var.reset(token)
+    assert payload["request_id"] == "abc123"
+
+
+def test_json_formatter_no_request_id_when_unset():
+    formatter = JsonFormatter()
+    # Make sure no prior test leaked an ID into the context.
+    assert request_id_var.get() is None
+    payload = json.loads(formatter.format(_make_record()))
+    assert "request_id" not in payload
+
+
+def test_json_formatter_includes_exc_info():
+    formatter = JsonFormatter()
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        import sys
+        record = _make_record("crash", level=logging.ERROR, exc_info=sys.exc_info())
+    payload = json.loads(formatter.format(record))
+    assert "exc_info" in payload
+    assert "ValueError: boom" in payload["exc_info"]
+
+
+def _client_with_middleware():
+    app = FastAPI()
+    install_request_id_middleware(app)
+    captured: dict = {}
+
+    @app.get("/echo")
+    def echo():
+        captured["rid"] = request_id_var.get()
+        return {"ok": True}
+
+    return TestClient(app), captured
+
+
+def test_middleware_generates_id_when_absent():
+    client, captured = _client_with_middleware()
+    resp = client.get("/echo")
+    assert resp.status_code == 200
+    rid = resp.headers["X-Request-Id"]
+    assert len(rid) == 32  # uuid4().hex
+    assert captured["rid"] == rid
+
+
+def test_middleware_honours_inbound_header():
+    client, captured = _client_with_middleware()
+    resp = client.get("/echo", headers={"X-Request-Id": "trace-xyz"})
+    assert resp.headers["X-Request-Id"] == "trace-xyz"
+    assert captured["rid"] == "trace-xyz"
+
+
+def test_middleware_logs_request_start_and_end(caplog):
+    client, _ = _client_with_middleware()
+    with caplog.at_level(logging.INFO, logger="simpler_objects.request"):
+        client.get("/echo", headers={"X-Request-Id": "rid-9"})
+    messages = [(r.levelname, r.message) for r in caplog.records
+                if r.name == "simpler_objects.request"]
+    assert ("INFO", "request.start") in messages
+    assert ("INFO", "request.end") in messages
+    # status should be attached to request.end
+    end = next(r for r in caplog.records if r.message == "request.end")
+    assert getattr(end, "status") == 200
+    assert hasattr(end, "latency_ms")
+
+
+def test_middleware_demotes_health_to_debug(caplog):
+    app = FastAPI()
+    install_request_id_middleware(app)
+
+    @app.get("/health")
+    def health():
+        return {"ok": True}
+
+    client = TestClient(app)
+    with caplog.at_level(logging.INFO, logger="simpler_objects.request"):
+        client.get("/health")
+    # No INFO records for /health — it's DEBUG.
+    info_records = [r for r in caplog.records
+                    if r.name == "simpler_objects.request" and r.levelno >= logging.INFO]
+    assert info_records == []


### PR DESCRIPTION
Closes #51.

## Summary
- Adds `simpler_objects.logging_config` with a stdlib-only `JsonFormatter`, a `request_id` `ContextVar`, and a FastAPI middleware that generates an ID per inbound request (or honours `X-Request-Id`) and echoes it on the response.
- The locator forwards `X-Request-Id` on every outbound `httpx` call, so a single ID threads through the client → locator → object-server hop. The bundled `simpler_objects.client` library also sends one on the wire.
- Domain-event logs at every notable site: PUT/GET success and failure modes (mismatch, busy, missing-by-phase, conflict, no-space), `safe_path` rejections, torn-checksum-line skips, locator server-selection results (with surviving candidates + weight), replication copy + done.
- `async_replicate` swaps `warnings.warn`/`print` for structured logger calls; the client library attaches a `NullHandler` and logs upload/download lifecycle.
- `LOG_LEVEL` env var controls verbosity (default `INFO`); README documents the format, correlation pattern, and the `--log-config` escape hatch for `fastapi run`.

## Test plan
- [x] `python -m pytest` — 88/88 pass (80 prior + 8 new in `tests/test_logging.py`).
- [x] Live cluster smoke test: PUT + GET through a 2-node cluster — one `request_id` appears on the client log, the locator's `locator.put.select` / `locator.find.redirect`, and the object-server's `object.put` / `object.get`.
- [x] `python -m simpler_objects.async_replicate ...` emits JSON only (no bare `print`/`warn`).
- [ ] Reviewer: confirm the `--log-config` workflow under `fastapi run` in your deployment shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)