### PR TITLE
OCI image for the locator (issue #17 stage 4)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Keep the container build context small — only ship what `pip install .`
+# actually needs (pyproject.toml, README.md, LICENSE, simpler_objects/).
+**/__pycache__/
+**/*.py[codz]
+*.egg-info/
+
+# Repo metadata
+.git/
+.gitignore
+.github/
+
+# Tests, demos, docs not needed in the image
+tests/
+upload-behavior-demo/
+deploy/
+openapi*.json
+openapi*.yaml
+review-*.md
+*.tmp
+CLAUDE.md
+CLAUDE.md.tmp
+perf_test.sh
+migrate_checksums.sh
+
+# Caches
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+htmlcov/
+
+# Editor cruft
+*.swp
+.vscode/
+.idea/

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ Note that ObjectIndex has a legacy way to manage this. Simply move your old file
 - run in screen
 - change `fastapi dev` to `fastapi run` for prod
 
+## Container (locator)
+
+The locator is stateless and ships an OCI image at [`deploy/container/`](deploy/container/). Build with `podman build -t simpler-objects-locator -f deploy/container/Containerfile .` and run with `-e OBJECT_SERVERS=...`. Object servers stay on systemd-managed bare metal because they need a persistent disk mount — see the deploy README for the rationale.
+
 ## Client guidance
 
 ### Redirects (307)

--- a/deploy/container/Containerfile
+++ b/deploy/container/Containerfile
@@ -1,0 +1,36 @@
+# OCI-compliant image for the simpler-objects locator only.
+# Build: `podman build -t simpler-objects-locator -f deploy/container/Containerfile .`
+# Run:   `podman run --rm -p 29164:29164 -e OBJECT_SERVERS=http://host:29171/ simpler-objects-locator`
+#
+# Object-server deployment is intentionally systemd-only (it requires a persistent
+# disk mount); see ../systemd/README.md for that side.
+
+# --- build stage --------------------------------------------------------------
+FROM python:3.12-slim AS build
+
+WORKDIR /src
+COPY pyproject.toml README.md LICENSE ./
+COPY simpler_objects/ ./simpler_objects/
+
+# Install into a relocatable prefix; runtime stage copies it to /usr/local.
+RUN pip install --no-cache-dir --prefix=/install .
+
+# --- runtime stage ------------------------------------------------------------
+FROM python:3.12-slim
+
+COPY --from=build /install /usr/local
+
+# Drop privileges.
+RUN useradd --system --no-create-home --shell /usr/sbin/nologin simpler-objects
+USER simpler-objects
+
+ENV PYTHONUNBUFFERED=1 \
+    HOST=0.0.0.0 \
+    PORT=29164 \
+    WORKERS=1
+
+EXPOSE 29164
+
+# `sh -c` lets ${HOST}/${PORT}/${WORKERS} expand from -e or ENV; `exec` makes
+# uvicorn PID 1 so SIGTERM/SIGINT from the container runtime reach it directly.
+CMD ["sh", "-c", "exec uvicorn simpler_objects.locator_api:app --host ${HOST} --port ${PORT} --workers ${WORKERS}"]

--- a/deploy/container/README.md
+++ b/deploy/container/README.md
@@ -1,0 +1,55 @@
+# Container (locator)
+
+OCI-compliant image for the **locator only**. Build runs against any Docker- or Podman-compatible builder; the produced image is `~165 MB` (debian-slim base + Python runtime + fastapi/uvicorn/httpx).
+
+## Why no object-server image
+
+The object server's storage is a persistent disk mounted at a host path (the Pi+USB case from issue #17). Putting that behind a container adds bind-mount and uid-mapping complexity for zero operational benefit over the systemd template in `../systemd/`. The locator is stateless and a natural fit for containerisation; the object server is not.
+
+## Build
+
+```
+podman build -t simpler-objects-locator -f deploy/container/Containerfile .
+# or
+docker build -t simpler-objects-locator -f deploy/container/Containerfile .
+```
+
+Multi-stage build: a `python:3.12-slim` build stage runs `pip install --prefix=/install .`, then the runtime stage copies that prefix into a fresh `python:3.12-slim` and drops to an unprivileged user. `pycurl` is in the `[client]` extra (not installed in this image) so the runtime needs no `libcurl` system package.
+
+## Run
+
+```
+podman run --rm -d --name locator \
+    -p 29164:29164 \
+    -e OBJECT_SERVERS=http://pi1.lan:29171/,http://pi2.lan:29171/ \
+    simpler-objects-locator
+```
+
+### Configuration
+
+All knobs are env vars (matching the systemd unit's conventions):
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `OBJECT_SERVERS` | — (no default; required) | Comma-separated locator backends; trailing slash required |
+| `HOST` | `0.0.0.0` | Bind address inside the container |
+| `PORT` | `29164` | Bind port inside the container |
+| `WORKERS` | `1` | uvicorn worker count |
+
+`OBJECT_SERVERS` has no default because there is no sensible one — the container needs to know how to reach the object servers on your network.
+
+### Healthcheck
+
+```
+curl http://<host>:29164/health
+```
+
+The shipped image does not declare a `HEALTHCHECK` instruction: the locator's `/health` makes outbound calls to every configured object server and can be slow under partial cluster failure; whether that should mark the container "unhealthy" is an orchestrator-level policy. Add `--health-cmd 'curl -fsS http://localhost:29164/health || exit 1'` at run time if your environment wants one.
+
+## Signals and lifecycle
+
+`CMD` is `sh -c 'exec uvicorn …'` — the `exec` makes uvicorn PID 1 inside the container, so `SIGTERM` from the container runtime reaches uvicorn directly and triggers a clean shutdown (no 10-second SIGKILL wait).
+
+## Run alongside object servers on a Pi
+
+The locator container can run on any host. If you co-locate it with an object server on the same Pi, expose the container to the host network or set `OBJECT_SERVERS=http://host.containers.internal:29171/` (podman) / `http://host.docker.internal:29171/` (docker) so the locator can reach the systemd-managed object server.


### PR DESCRIPTION
## Summary

Final stage of issue #17. Builds on Stage 1 (`pyproject.toml`, merged to main in `09896f1`); independent of PR #67 (Stages 2+3 — systemd units + scheduling examples) and can merge in either order.

- **`deploy/container/Containerfile`** — multi-stage build on `python:3.12-slim`. Build stage runs `pip install --prefix=/install .`; runtime stage copies the prefix and drops to the unprivileged `simpler-objects` user. `pycurl` is in the `[client]` extra, so no `libcurl` system package is needed in the runtime stage. Image is **~165 MB**.
- **CMD pattern**: `sh -c 'exec uvicorn …'` — `${HOST}`/`${PORT}`/`${WORKERS}` env vars expand, and `exec` makes uvicorn PID 1 so the container runtime's `SIGTERM` reaches it directly (clean shutdown, no 10s kill wait).
- **`.dockerignore`** — keeps the build context to what `pip install .` actually needs (pyproject.toml, README.md, LICENSE, `simpler_objects/`). Excludes `.git`, `tests/`, `deploy/`, demos, openapi dumps, caches.
- **`deploy/container/README.md`** — build/run/config walkthrough plus the rationale for NOT shipping an object-server image (persistent disk mount → systemd is the right fit).
- Top-level `README.md` gets a short "Container (locator)" subsection pointing to `deploy/container/`.

## Verified locally

- `podman build -t simpler-objects-locator -f deploy/container/Containerfile .` succeeded.
- Container started; uvicorn bound to `0.0.0.0:29164` (PID 1).
- `curl http://127.0.0.1:29164/health` (from inside the container) returned 200 with the expected JSON shape, correctly reporting a misconfigured `OBJECT_SERVERS=http://nonexistent:29171/` as unhealthy.

## Note on conflicts with #67

Both this PR and #67 add a new section to `README.md` after `## Setting up storage servers`. They don't textually overlap, but git may flag a conflict depending on merge order — whichever lands second will need a one-line rebase to keep both subsections.

## Test plan

- [ ] `podman build -t simpler-objects-locator -f deploy/container/Containerfile .` on Fedora.
- [ ] `docker build` equivalent on a Docker host.
- [ ] Run with a real two-node cluster: `podman run --rm -d -p 29164:29164 -e OBJECT_SERVERS=http://pi1.lan:29171/,http://pi2.lan:29171/ simpler-objects-locator`, then `simple_upload` / `simple_download` through the containerised locator.
- [ ] Confirm `podman stop locator` shuts down quickly (no 10s `SIGKILL` wait — validates the `exec` in CMD).
- [ ] Confirm image size is in a reasonable range (target ≤ 200 MB; local build was 165 MB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)