### PR TITLE
Object DELETE with per-bucket RBAC (v0.6.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ python -m simpler_objects.scrub /path/to/objects
 python -m simpler_objects.scrub --delete-victims --repair-checksums /path/to/objects
 ```
 
-A "crash victim" is any file in a bucket directory without a matching valid line in `<bucket>.sha256`. The scrub assumes the server is stopped — it doesn't coordinate with a running server.
+A "crash victim" is any file in a bucket directory without a matching valid line in `<bucket>.sha256`. A "stale" entry is the reverse — a valid checksum line whose file is missing. Since v0.6.0 every `DELETE` produces one deliberately (the line is left as a tombstone), so after any deletion the dry-run scrub reports findings and exits nonzero: expect the systemd unit's `ExecStartPre` scrub to hold the next restart until you run `--repair-checksums` (which erases the tombstones — deleted keys become recreatable again). The scrub assumes the server is stopped — it doesn't coordinate with a running server.
 
 ## On-disk format
 
@@ -129,6 +129,8 @@ For cron-based replication scheduling (alternative to the systemd timer), see [`
 ### Redirects (307)
 
 The locator returns `307 Temporary Redirect` for `GET`, `HEAD`, and `PUT` on `/{bucket}/{key}`. Clients must follow redirects and must preserve the original HTTP method — particularly for PUT. Use `curl -L`; verify your HTTP library honours 307 method preservation for non-GET requests.
+
+`DELETE` is the exception: the locator answers it directly (no redirect) — the object may be replicated, so the locator fans the DELETE out to every object server itself. See "Changes in spec v0.6.0" below.
 
 ### `Expect: 100-continue` on PUT
 
@@ -195,6 +197,12 @@ def simple_upload(filename, url, file_mime, checksum_val=None):
 
 Clients may send `Content-Digest` or `Repr-Digest` with a SHA-256 value (`sha-256=:base64:` format) for integrity verification. The object server returns `400` on mismatch. The `Repr-Digest` header on GET/HEAD responses is present only when a checksum record exists for the object — do not assume it is always included.
 
+### Changes in spec v0.6.0
+
+- **`DELETE /{bucket}/{key}` is now supported.** On the locator it is **not a redirect**: the locator sends DELETE to every object server and aggregates — `204` when at least one copy was deleted and every server answered `204` or `404`; `404` when no server held a copy; `503` + `Retry-After` when any server was unreachable, mid-upload, or read-only (a copy may survive — **retry until you get `204` or `404`**, otherwise replication can restore the surviving copy). On a secured cluster the operation requires the new `delete` permission on the bucket.
+- **Deleted keys are permanently write-once.** The object server unlinks the file but keeps the key's `<bucket>.sha256` line as a tombstone; a later `PUT` of the same key returns `409`. (Operators can erase tombstones with `scrub --repair-checksums`; see Post-crash scrub.)
+- **`sha256sum -c` validation** of a bucket that has seen deletions reports the deleted keys as missing files — expected, not corruption.
+
 ### Changes in spec v0.5.0
 
 - **Authentication is available and opt-in** — see the next section. Nothing breaks for unconfigured clusters, but clients targeting a secured cluster must send an API key to the locator, and can no longer hit object servers directly without a signed URL.
@@ -205,7 +213,7 @@ Clients may send `Content-Digest` or `Repr-Digest` with a SHA-256 value (`sha-25
 
 Both are **off by default** — an unconfigured cluster behaves exactly as before. When enabled (see [`deploy/systemd/README.md`](deploy/systemd/README.md) for server setup):
 
-- **API keys at the locator.** Every object and bucket operation on the locator requires an `Authorization` header. Programmatic clients send `Authorization: Bearer <key>`; browsers can simply answer the HTTP Basic prompt with the client name as username and the key as password (`curl -u oi:$KEY` works too). Missing/invalid credentials → `401` with a `WWW-Authenticate: Basic` challenge; a valid client without permission for that bucket/operation → `403`. Keys map to per-bucket permissions of `read` (GET/HEAD object), `write` (PUT), and `list` (bucket listing).
+- **API keys at the locator.** Every object and bucket operation on the locator requires an `Authorization` header. Programmatic clients send `Authorization: Bearer <key>`; browsers can simply answer the HTTP Basic prompt with the client name as username and the key as password (`curl -u oi:$KEY` works too). Missing/invalid credentials → `401` with a `WWW-Authenticate: Basic` challenge; a valid client without permission for that bucket/operation → `403`. Keys map to per-bucket permissions of `read` (GET/HEAD object), `write` (PUT), `list` (bucket listing), and `delete` (DELETE object, since v0.6.0).
 - **Signed redirect URLs.** The locator's `307 Location` carries `?exp=<unix-seconds>&sig=<hmac>` — a short-lived signed URL (default 15 minutes) the object server accepts with **no credentials**. Just follow the redirect; never send your API key to an object server and never compute signatures yourself. Only the *start* of a request must land inside the validity window, so long transfers are safe. If you save a redirect URL and it expires (e.g. resuming a download), re-request the object from the locator to get a fresh one. Direct object-server requests without a valid signature return `401`/`403`.
 - **`simpler_objects.client`** grows `api_key=` and `ca_bundle=` keyword arguments on `simple_upload`/`simple_download`: the key rides the locator leg as a Bearer header (libcurl drops it on the cross-host redirect, which is correct — the signed URL takes over), and `ca_bundle` points at the private CA's PEM for HTTPS verification.
 - **Use keys only over HTTPS.** Bearer and Basic credentials are plaintext headers; on plain HTTP anyone on the network path can read them.

--- a/deploy/ansible/roles/simpler_objects_locator/templates/auth.toml.j2
+++ b/deploy/ansible/roles/simpler_objects_locator/templates/auth.toml.j2
@@ -1,6 +1,7 @@
 {{ ansible_managed | comment('#') }}
 # Client API keys and per-bucket permissions for the simpler-objects locator.
-# Operations: read (GET/HEAD object), write (PUT object), list (bucket listing).
+# Operations: read (GET/HEAD object), write (PUT object), list (bucket listing),
+# delete (DELETE object).
 # A bucket entry of "*" applies to any bucket without an exact entry.
 {% for name, entry in locator_auth_clients.items() %}
 

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -215,6 +215,11 @@ Every start of `simpler-objects-object-server` runs
 orphan partial file or a garbled `<bucket>.sha256` line, scrub exits non-zero
 and the unit refuses to start.
 
+Deletions trip this preflight too (since v0.6.0): every `DELETE` leaves the
+key's checksum line behind as a stale-entry tombstone, so after any deletion
+the next restart requires the same `--repair-checksums` recovery below. Note
+that repairing erases the tombstones — deleted keys become recreatable again.
+
 On a clean directory this is near-instant. The cost scales with file count.
 
 ### Recovering from a scrub failure

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Simpler Objects API
-  version: 0.5.0
+  version: 0.6.0
   description: >
     Example hash values throughout this spec represent SHA-256("hello"):
     hex `2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824`,
@@ -446,8 +446,11 @@ paths:
                 detail: Uploaded content does not match the provided Content-Digest header
         '409':
           description: >
-            Object already exists, or a PUT of the same key is currently in
-            progress (object-server only). Keys are immutable once written.
+            Object already exists, a PUT of the same key is currently in
+            progress, or the key was previously deleted (object-server only).
+            Keys are immutable once written and permanently write-once: a
+            deleted key's checksum entry remains as a tombstone, so the key
+            cannot be recreated.
           content:
             application/problem+json:
               schema:
@@ -507,6 +510,100 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
         '500':
           description: Internal server error (object-server only).
+    delete:
+      tags:
+        - Objects
+      summary: Delete Object
+      description: >
+        Delete an object. On an object server the file is unlinked but its
+        checksum entry is left in place as a tombstone: the key is permanently
+        write-once and cannot be recreated (a later PUT of the same key
+        returns `409`), and the entry is reported by the post-crash scrub as
+        stale until the operator runs `--repair-checksums`.
+
+
+        The locator does *not* redirect DELETE (unlike GET/HEAD/PUT): the
+        object may exist on several servers and every copy must go, so the
+        locator sends DELETE to every object server itself and aggregates the
+        results. It returns `204` only when at least one server deleted a copy
+        and every server answered `204` or `404`; any other answer (server
+        unreachable, mid-upload `503`, read-only `405`) yields a retriable
+        `503` because a copy may survive.
+      operationId: deleteObject
+      security:
+      - {}
+      - basicAuth: []
+      - bearerAuth: []
+      - signedUrl: []
+      parameters:
+      - name: bucket
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Bucket
+        example: my-bucket
+      - name: key
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Key
+        example: document.pdf
+      - $ref: '#/components/parameters/SignedExp'
+      - $ref: '#/components/parameters/SignedSig'
+      responses:
+        '204':
+          description: >
+            Object deleted. From the locator, every server answered and no
+            copy remains anywhere in the cluster.
+        '401':
+          description: >
+            Authentication required (only when auth is enabled). From an
+            object server, the `exp`/`sig` query parameters are missing. From
+            the locator, no valid API key was presented.
+          headers:
+            WWW-Authenticate:
+              required: false
+              schema:
+                type: string
+              description: >
+                Sent by the locator. Advertises Basic (username = client
+                name, password = API key) so browsers prompt; a Bearer
+                header carrying the bare key is accepted equally.
+              example: 'Basic realm="simpler-objects", charset="UTF-8"'
+        '403':
+          description: >
+            Not authorized (only when auth is enabled). From an object
+            server, the signature is invalid, expired, or minted for a
+            different operation. From the locator, the authenticated client
+            lacks permission for this operation on this bucket.
+        '404':
+          description: >
+            Object not found. From the locator, no server holds a copy (the
+            object never existed or was already deleted).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        '405':
+          description: Method Not Allowed — server is configured as read-only (object-server only)
+        '422':
+          description: Validation Error
+        '500':
+          description: Internal server error (object-server only).
+        '503':
+          description: >
+            Deletion could not complete. From an object server, a PUT of this
+            key is in progress. From the locator, at least one server did not
+            answer `204` or `404` — a copy may survive — so the DELETE must be
+            retried after the delay in the `Retry-After` header.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Suggested retry delay in seconds
+              example: 64
   /{bucket}/:
     get:
       tags:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "simpler-objects"
-version = "0.5.0"
+version = "0.6.0"
 description = "A simpler object storage service"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/simpler_objects/auth.py
+++ b/simpler_objects/auth.py
@@ -30,6 +30,7 @@ import time
 OP_READ = "read"
 OP_WRITE = "write"
 OP_LIST = "list"
+OP_DELETE = "delete"
 
 # Seconds past `exp` a signature is still accepted, absorbing clock drift
 # between locator and object servers. The effective replay window is
@@ -99,7 +100,7 @@ class AuthConfig:
             if not isinstance(entry.get("key"), str) or not entry["key"]:
                 raise ValueError(f"auth config client {name!r}: missing or empty key")
             for bucket, ops in entry.get("buckets", {}).items():
-                bad = set(ops) - {OP_READ, OP_WRITE, OP_LIST}
+                bad = set(ops) - {OP_READ, OP_WRITE, OP_LIST, OP_DELETE}
                 if bad:
                     raise ValueError(
                         f"auth config client {name!r} bucket {bucket!r}: "

--- a/simpler_objects/locator_api.py
+++ b/simpler_objects/locator_api.py
@@ -194,6 +194,40 @@ async def add_object(bucket: str, key: str,
     return RedirectResponse(url=server_to_upload + object_path
                             + signed_suffix(auth.OP_WRITE, bucket, key))
 
+@app.delete("/{bucket}/{key}", dependencies=[Depends(require_permission(auth.OP_DELETE))])
+async def delete_object(bucket: str, key: str):
+    """Delete an object from every server that holds a copy.
+
+    Unlike GET/HEAD/PUT this is not a redirect: the object may exist on
+    several servers and every copy must go, so the locator issues the
+    DELETEs itself. It sends DELETE to all servers rather than probing for
+    holders first — a server without the object answers a harmless 404, and
+    there is no probe-to-delete race window.
+    """
+    object_path = f"{bucket}/{key}"
+    client = app.state.client
+    suffix = signed_suffix(auth.OP_DELETE, bucket, key)
+
+    async def delete_on(server):
+        try:
+            result = await client.delete(server + object_path + suffix, timeout=8)
+            return result.status_code
+        except httpx.HTTPError:
+            return None
+
+    statuses = await asyncio.gather(*[delete_on(s) for s in object_servers()])
+
+    if any(s not in (204, 404) for s in statuses):
+        # A copy may survive on an unreachable, busy, or read-only server;
+        # only when every server answers 204 or 404 is the deletion complete,
+        # so anything else is retriable. 503, not 502/504: the locator
+        # coordinates object servers but is not itself a gateway/proxy.
+        raise HTTPException(status_code=503,
+                            headers={"Retry-After": RETRY_AFTER})
+    if 204 in statuses:
+        return Response(status_code=204)
+    raise HTTPException(status_code=404)
+
 @app.get("/")
 def list_buckets():
     """List buckets — not permitted"""

--- a/simpler_objects/object_server.py
+++ b/simpler_objects/object_server.py
@@ -159,6 +159,12 @@ async def put_object(bucket: str, key: str, request: Request,
 
     path = object_filename(bucket, key)
 
+    # A checksum line with no file is a tombstone left by DELETE: the key is
+    # permanently write-once, so recreating it is refused. (Also protects the
+    # stale line from ever shadowing a fresh digest — lookup is first-match.)
+    if ChecksumFile(path.parent).lookup(key) is not None:
+        raise HTTPException(status_code=409)
+
     # O_EXCL creates the object atomically: an existing key — or a racing
     # same-key PUT that won the create — lands here as 409.
     try:
@@ -200,6 +206,39 @@ async def put_object(bucket: str, key: str, request: Request,
             raise
     finally:
         os.close(fd)
+
+@app.delete("/{bucket}/{key}", dependencies=[Depends(require_signature(auth.OP_DELETE))])
+def delete_object(bucket: str, key: str):
+    """Unlink an object, leaving its checksum line in place as a tombstone.
+
+    The line keeps the key permanently write-once (PUT refuses to recreate
+    it) and is reported by scrub as a stale entry until the operator runs
+    --repair-checksums.
+    """
+    if READ_ONLY:
+        raise HTTPException(status_code=405)
+    path = object_filename(bucket, key)
+    try:
+        fd = os.open(path, os.O_RDONLY)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404) from None
+    try:
+        # An exclusive lock, tested non-blocking: if a PUT holds the file the
+        # object is mid-upload — fail fast and retriable rather than yanking
+        # the file out from under the writer.
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            raise HTTPException(status_code=503,
+                                headers={"Retry-After": RETRY_AFTER}) from None
+        # Re-check: a failed PUT or a racing DELETE may have unlinked the
+        # file between the open above and acquiring the lock.
+        if not path.is_file():
+            raise HTTPException(status_code=404)
+        path.unlink()
+    finally:
+        os.close(fd)
+    return Response(status_code=204)
 
 @app.get("/")
 def list_buckets():

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -207,9 +207,18 @@ def test_load_rejects_missing_key(tmp_path):
 
 def test_load_rejects_unknown_operation(tmp_path):
     path = tmp_path / "auth.toml"
-    path.write_text("[clients.c]\nkey = 'k'\n[clients.c.buckets]\nb = ['delete']\n")
+    path.write_text("[clients.c]\nkey = 'k'\n[clients.c.buckets]\nb = ['purge']\n")
     with pytest.raises(ValueError):
         auth.AuthConfig.load(path)
+
+
+def test_load_accepts_delete_operation(tmp_path):
+    path = tmp_path / "auth.toml"
+    path.write_text("[clients.c]\nkey = 'k'\n[clients.c.buckets]\nb = ['delete']\n")
+    path.chmod(0o600)
+    config = auth.AuthConfig.load(path)
+    assert config.allowed("c", "b", auth.OP_DELETE)
+    assert not config.allowed("c", "b", auth.OP_READ)
 
 
 def test_load_warns_on_loose_permissions(tmp_path, capsys):

--- a/tests/test_locator_api.py
+++ b/tests/test_locator_api.py
@@ -304,6 +304,64 @@ def test_add_object_content_type_octet_stream_accepted(client):
 
 
 # ---------------------------------------------------------------------------
+# DELETE /{bucket}/{key} — fan-out, not a redirect
+# ---------------------------------------------------------------------------
+
+@respx.mock
+def test_delete_object_success(client):
+    """One holder deleted, the other never had it → 204, both servers asked."""
+    route_a = respx.delete(SERVER_A + OBJ_PATH).mock(return_value=httpx.Response(204))
+    route_b = respx.delete(SERVER_B + OBJ_PATH).mock(return_value=httpx.Response(404))
+    resp = client.delete(f"/{OBJ_PATH}")
+    assert resp.status_code == 204
+    assert route_a.called
+    assert route_b.called
+
+
+@respx.mock
+def test_delete_object_replicated(client):
+    """Every replica must go: both servers deleted → 204."""
+    respx.delete(SERVER_A + OBJ_PATH).mock(return_value=httpx.Response(204))
+    respx.delete(SERVER_B + OBJ_PATH).mock(return_value=httpx.Response(204))
+    assert client.delete(f"/{OBJ_PATH}").status_code == 204
+
+
+@respx.mock
+def test_delete_object_not_found(client):
+    respx.delete(SERVER_A + OBJ_PATH).mock(return_value=httpx.Response(404))
+    respx.delete(SERVER_B + OBJ_PATH).mock(return_value=httpx.Response(404))
+    assert client.delete(f"/{OBJ_PATH}").status_code == 404
+
+
+@respx.mock
+def test_delete_object_unreachable_server_503(client):
+    """An unreachable server may still hold a copy — retriable 503, and the
+    reachable server's delete still goes through."""
+    respx.delete(SERVER_A + OBJ_PATH).mock(side_effect=httpx.ConnectError("down"))
+    route_b = respx.delete(SERVER_B + OBJ_PATH).mock(return_value=httpx.Response(204))
+    resp = client.delete(f"/{OBJ_PATH}")
+    assert resp.status_code == 503
+    assert "Retry-After" in resp.headers
+    assert route_b.called
+
+
+@respx.mock
+def test_delete_object_mid_upload_503(client):
+    """A 503 (PUT in progress) from any server keeps the delete retriable."""
+    respx.delete(SERVER_A + OBJ_PATH).mock(return_value=httpx.Response(503))
+    respx.delete(SERVER_B + OBJ_PATH).mock(return_value=httpx.Response(404))
+    assert client.delete(f"/{OBJ_PATH}").status_code == 503
+
+
+@respx.mock
+def test_delete_object_readonly_server_503(client):
+    """A read-only server (405) refuses to delete its copy → retriable 503."""
+    respx.delete(SERVER_A + OBJ_PATH).mock(return_value=httpx.Response(405))
+    respx.delete(SERVER_B + OBJ_PATH).mock(return_value=httpx.Response(204))
+    assert client.delete(f"/{OBJ_PATH}").status_code == 503
+
+
+# ---------------------------------------------------------------------------
 # HEAD /{bucket}/
 # ---------------------------------------------------------------------------
 
@@ -483,6 +541,15 @@ def test_list_bucket_fanout_signed(secured_client):
 
 
 @respx.mock
+def test_delete_fanout_signed(secured_client):
+    route_a = respx.delete(SERVER_A + OBJ_PATH).mock(return_value=httpx.Response(204))
+    route_b = respx.delete(SERVER_B + OBJ_PATH).mock(return_value=httpx.Response(404))
+    assert secured_client.delete(f"/{OBJ_PATH}").status_code == 204
+    _assert_signed(route_a.calls[0].request.url, auth.OP_DELETE, key=KEY)
+    _assert_signed(route_b.calls[0].request.url, auth.OP_DELETE, key=KEY)
+
+
+@respx.mock
 def test_no_secret_means_bare_urls(client):
     """Without CLUSTER_SECRET the Location has no query — today's contract."""
     respx.head(SERVER_A + OBJ_PATH).mock(return_value=httpx.Response(200))
@@ -504,7 +571,7 @@ AUTH_TOML = f"""
 [clients.oi]
 key = "{OI_KEY}"
 [clients.oi.buckets]
-{BUCKET} = ["read", "write", "list"]
+{BUCKET} = ["read", "write", "list", "delete"]
 
 [clients.ro]
 key = "{RO_KEY}"
@@ -621,6 +688,27 @@ def test_authorized_put_redirects_signed(authed_client):
                              follow_redirects=False)
     assert resp.status_code == 307
     _assert_signed(resp.headers["location"], auth.OP_WRITE, key=KEY)
+
+
+@respx.mock
+def test_read_only_client_cannot_delete(authed_client):
+    resp = authed_client.delete(f"/{OBJ_PATH}", headers=_bearer(RO_KEY))
+    assert resp.status_code == 403
+
+
+@respx.mock
+def test_authorized_delete(authed_client):
+    respx.delete(SERVER_A + OBJ_PATH).mock(return_value=httpx.Response(204))
+    respx.delete(SERVER_B + OBJ_PATH).mock(return_value=httpx.Response(404))
+    resp = authed_client.delete(f"/{OBJ_PATH}", headers=_bearer(OI_KEY))
+    assert resp.status_code == 204
+
+
+@respx.mock
+def test_unauthenticated_delete_401(authed_client):
+    resp = authed_client.delete(f"/{OBJ_PATH}")
+    assert resp.status_code == 401
+    assert resp.headers["WWW-Authenticate"].startswith("Basic")
 
 
 @respx.mock

--- a/tests/test_object_server.py
+++ b/tests/test_object_server.py
@@ -165,6 +165,50 @@ def test_get_locked_object_returns_503(uploaded, tmp_path):
         os.close(fd)
 
 
+def test_delete(uploaded, tmp_path):
+    """DELETE unlinks the file but leaves the checksum line as a tombstone."""
+    resp = uploaded.delete(f"/{BUCKET}/{TEST_FILE}")
+    assert resp.status_code == 204
+    assert not (tmp_path / BUCKET / TEST_FILE).exists()
+    assert TEST_FILE in (tmp_path / f"{BUCKET}.sha256").read_text()
+    assert uploaded.get(f"/{BUCKET}/{TEST_FILE}").status_code == 404
+
+
+def test_delete_missing_object(client):
+    """DELETE of a key that was never stored returns 404."""
+    resp = client.delete(f"/{BUCKET}/never-stored.bin")
+    assert resp.status_code == 404
+
+
+def test_readonly_delete_rejected(readonly_client, tmp_path):
+    obj_path = tmp_path / BUCKET / TEST_FILE
+    obj_path.write_bytes(TEST_CONTENT)
+    resp = readonly_client.delete(f"/{BUCKET}/{TEST_FILE}")
+    assert resp.status_code == 405
+    assert obj_path.exists()
+
+
+def test_delete_locked_object_returns_503(uploaded, tmp_path):
+    """A DELETE while a PUT holds the exclusive lock returns 503 + Retry-After."""
+    fd = os.open(tmp_path / BUCKET / TEST_FILE, os.O_RDONLY)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        resp = uploaded.delete(f"/{BUCKET}/{TEST_FILE}")
+        assert resp.status_code == 503
+        assert resp.headers["Retry-After"] == "64"
+        assert (tmp_path / BUCKET / TEST_FILE).exists()
+    finally:
+        os.close(fd)
+
+
+def test_put_after_delete_conflict(uploaded, tmp_path):
+    """A deleted key is permanently write-once: its tombstone makes PUT 409."""
+    assert uploaded.delete(f"/{BUCKET}/{TEST_FILE}").status_code == 204
+    resp = uploaded.put(f"/{BUCKET}/{TEST_FILE}", content=b"new content")
+    assert resp.status_code == 409
+    assert not (tmp_path / BUCKET / TEST_FILE).exists()
+
+
 def test_put_no_space_returns_507(client, tmp_path, monkeypatch):
     """PUT returns 507 and leaves no partial file when disk is full."""
     def fsync_enospc(fd):
@@ -274,6 +318,29 @@ def test_wrong_operation_signature_rejected_403(secured, tmp_path):
     resp = secured.put(f"/{BUCKET}/{TEST_FILE}" + _sq(auth.OP_READ), content=TEST_CONTENT)
     assert resp.status_code == 403
     assert not (tmp_path / BUCKET / TEST_FILE).exists()
+
+
+def test_signed_delete_round_trip(secured):
+    assert secured.put(f"/{BUCKET}/{TEST_FILE}" + _sq(auth.OP_WRITE),
+                       content=TEST_CONTENT).status_code == 201
+    resp = secured.delete(f"/{BUCKET}/{TEST_FILE}" + _sq(auth.OP_DELETE))
+    assert resp.status_code == 204
+
+
+def test_unsigned_delete_rejected_401(secured, tmp_path):
+    obj_path = tmp_path / BUCKET / TEST_FILE
+    obj_path.write_bytes(TEST_CONTENT)
+    assert secured.delete(f"/{BUCKET}/{TEST_FILE}").status_code == 401
+    assert obj_path.exists()
+
+
+def test_write_signature_does_not_authorize_delete(secured, tmp_path):
+    """A write signature must not authorize a DELETE."""
+    assert secured.put(f"/{BUCKET}/{TEST_FILE}" + _sq(auth.OP_WRITE),
+                       content=TEST_CONTENT).status_code == 201
+    resp = secured.delete(f"/{BUCKET}/{TEST_FILE}" + _sq(auth.OP_WRITE))
+    assert resp.status_code == 403
+    assert (tmp_path / BUCKET / TEST_FILE).exists()
 
 
 def test_wrong_key_signature_rejected_403(secured):


### PR DESCRIPTION
Stacked on #84. Adds `DELETE /{bucket}/{key}` to both tiers.

## Behavior

- **Object server** unlinks the file under a non-blocking exclusive `flock` (`503` + `Retry-After` if a PUT is in flight, `405` when read-only, `404` when missing) and **leaves the `<bucket>.sha256` line in place as a tombstone**: deleted keys are permanently write-once — a later PUT of the same key returns `409`.
- **Locator** does *not* redirect DELETE (the object may be replicated and every copy must go): it sends signed DELETEs to every object server concurrently and aggregates — `204` when at least one copy was deleted and all servers answered `204`/`404`; `404` when none held a copy; retriable `503` + `Retry-After` when any server was unreachable/mid-upload/read-only, since a copy may survive. Clients must retry until `204`/`404`, otherwise replication can restore the surviving copy.
- **RBAC**: new `delete` operation joins `read`/`write`/`list` — signed object-server URLs carry it, and with `AUTH_CONFIG` set the client key needs `delete` on the bucket (`403` without, `401` unauthenticated).
- **Scrub stays strict by design**: each delete leaves a stale entry, so the systemd `ExecStartPre` dry-run scrub holds the next object-server restart until the operator runs `--repair-checksums` (which erases the tombstones). Documented in the README, the deploy runbook, and the spec.

`openapi.yaml` gains the `delete` operation (drift/response-validation tests enforce it) and the version bumps to 0.6.0.

## Testing

- 22 new tests: object-server unlink/tombstone/lock/read-only/signature cases, locator fan-out aggregation (success, all-404, unreachable, mid-upload 503, read-only 405), RBAC allow/deny, auth config accepts `delete` (the unknown-op test now uses `purge`). Full suite: 224 passed.
- Verified end-to-end against a live 2-server scratch cluster: PUT → replicate → DELETE (204, files gone, checksum lines intact), GET 404, re-PUT 409, DELETE with one server down → 503 + surviving copy deleted on retry after recovery → 204, scrub dry-run exit 1 → `--repair-checksums` → clean, and the secured cluster (401 no creds / 403 read-only key / 401 unsigned direct / 204 admin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)